### PR TITLE
Add registered ros plugins to BT editor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ if(catkin_FOUND)
     CATKIN_DEPENDS behaviortree_cpp
     DEPENDS 
     )
+   add_definitions( -DUSING_ROS )
 endif(catkin_FOUND)
 #############################################################
 

--- a/bt_editor/bt_editor_base.cpp
+++ b/bt_editor/bt_editor_base.cpp
@@ -194,6 +194,9 @@ const NodeModels &BuiltinNodeModels()
 
         factory.registerNodeType<BT::DecoratorSubtreeNode>("Root");
 
+#ifdef USING_ROS
+        factory.registerFromROSPlugins();
+#endif
         NodeModels out;
         for( const auto& it: factory.manifests())
         {


### PR DESCRIPTION
This requires https://github.com/BehaviorTree/BehaviorTree.CPP/pull/53

It will load automatically plugins registered using ROS to the GUI.

See for instance a screenshot where "ComputeIk" and "OmplPlan" have been loaded automatically.

![image](https://user-images.githubusercontent.com/3469405/53418804-e6d5c800-39d8-11e9-83e2-7be10b04ecb1.png)
