### PR TITLE
Stop using QDomDocument::toString to avoid QHash random reordering

### DIFF
--- a/bt_editor/mainwindow.h
+++ b/bt_editor/mainwindow.h
@@ -141,7 +141,13 @@ private:
     void refreshNodesLayout(QtNodes::PortLayout new_layout);
 
     void refreshExpandedSubtrees();
-    
+
+    void streamElementAttributes(QXmlStreamWriter &stream, const QDomElement &element) const;
+
+    QString xmlDocumentToString(const QDomDocument &document) const;
+
+    void recursivelySaveNodeCanonically(QXmlStreamWriter &stream, const QDomNode &parent_node) const;
+
     struct SavedState
     {
         QString main_tree;

--- a/test_data/crossdoor_with_subtree.xml
+++ b/test_data/crossdoor_with_subtree.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <root main_tree_to_execute="MainTree">
     <!-- ////////// -->
     <BehaviorTree ID="DoorClosed">

--- a/test_data/test_files.qrc
+++ b/test_data/test_files.qrc
@@ -1,6 +1,7 @@
 <RCC>
     <qresource prefix="/">
         <file>crossdoor_with_subtree.xml</file>
+        <file>test_xml_key_reordering_issue.xml</file>
         <file>crossdoor_palette.xml</file>
         <file>show_all.xml</file>
         <file>crossdoor_trace.fbl</file>

--- a/test_data/test_xml_key_reordering_issue.xml
+++ b/test_data/test_xml_key_reordering_issue.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0"?>
+<root main_tree_to_execute="BehaviorTree">
+    <!-- ////////// -->
+    <BehaviorTree ID="BehaviorTree">
+        <Sequence>
+            <Action ID="ReceiveTargetPose" target_pose="{target_pose}"/>
+            <Action ID="LoadConstraints" constrain_a="{constraint_a}" constraint_b="{constraint_b}" constraint_c="{constraint_c}" file="&quot;configuration.yaml&quot;"/>
+            <SubTree ID="RunPlannerSubtree" constraint_a="constraint_a" constraint_b="constraint_b" constraint_c="constraint_c" path="path" target_pose="target_pose"/>
+            <SubTree ID="ExecutePath" path="path"/>
+        </Sequence>
+    </BehaviorTree>
+    <!-- ////////// -->
+    <BehaviorTree ID="ExecutePath">
+        <Fallback>
+            <Sequence>
+                <Condition ID="OnAir"/>
+                <Action ID="Fly" path="{path}"/>
+            </Sequence>
+            <Sequence>
+                <Condition ID="OnGround"/>
+                <Action ID="Roll" path="{path}"/>
+            </Sequence>
+            <Sequence>
+                <Condition ID="OnWater"/>
+                <Action ID="Swim" path="{path}"/>
+            </Sequence>
+        </Fallback>
+    </BehaviorTree>
+    <!-- ////////// -->
+    <BehaviorTree ID="RunPlannerSubtree">
+        <Fallback>
+            <Action ID="RunPlannerA" constraint_a="{constraint_a}" constraint_b="{constraint_b}" contratint_c="{constraint_c}" path="{path}" target_pose="{target_pose}"/>
+            <Action ID="RunPlannerB" constraint_a="{constraint_a}" constraint_b="{constraint_b}" constraint_c="{constraint_c}" path="{path}" target_pose="{target_pose}"/>
+        </Fallback>
+    </BehaviorTree>
+    <!-- ////////// -->
+    <TreeNodesModel>
+        <SubTree ID="ExecutePath">
+            <input_port name="path"/>
+        </SubTree>
+        <Action ID="Fly">
+            <input_port name="path"/>
+        </Action>
+        <Action ID="LoadConstraints">
+            <output_port name="constrain_a"/>
+            <output_port name="constraint_b"/>
+            <output_port name="constraint_c"/>
+            <input_port name="file"/>
+        </Action>
+        <Condition ID="OnAir"/>
+        <Condition ID="OnGround"/>
+        <Condition ID="OnWater"/>
+        <Action ID="ReceiveTargetPose">
+            <output_port name="target_pose"/>
+        </Action>
+        <Action ID="Roll">
+            <input_port name="path"/>
+        </Action>
+        <Action ID="RunPlannerA">
+            <input_port name="constraint_a"/>
+            <input_port name="constraint_b"/>
+            <input_port name="contratint_c"/>
+            <output_port name="path"/>
+            <input_port name="target_pose"/>
+        </Action>
+        <Action ID="RunPlannerB">
+            <input_port name="constraint_a"/>
+            <input_port name="constraint_b"/>
+            <input_port name="constraint_c"/>
+            <output_port name="path"/>
+            <input_port name="target_pose"/>
+        </Action>
+        <SubTree ID="RunPlannerSubtree">
+            <input_port name="constraint_a"/>
+            <input_port name="constraint_b"/>
+            <input_port name="constraint_c"/>
+            <output_port name="path"/>
+            <input_port name="target_pose"/>
+        </SubTree>
+        <Action ID="Swim">
+            <input_port name="path"/>
+        </Action>
+    </TreeNodesModel>
+    <!-- ////////// -->
+</root>
+


### PR DESCRIPTION
This PR fixes a random reordering of keys in the xml output file that happens each time the file is saved from a new Groot process, even if no changes were made to the tree. 

The issue can be replicated by creating a tree description xml file that has nodes with multiple input or output ports (the `test_data/test_xml_key_reordering_issue.xml` included in this PR, for instance). Open Groot, load the file and save a copy of it. Close and start Groot again, open the file again a save a second copy. Then compare the original with both copies using `diff`; there should be differences in the ordering of xml attributes.

This becomes an issue when the xml file is stored in a version control system such as git.

The random reordering happens because newer versions of the `QDomDocument` uses `QHash`, which in newer versions of the Qt library [uses randomness to prevent certain types of DoS attacks](https://doc.qt.io/qt-5/qhash.html#algorithmic-complexity-attacks).

[There are provisions to prevent the random reordering from within the Qt library](https://doc.qt.io/qt-5/qhash.html#qSetGlobalQHashSeed), but they are not the same in all versions of Qt.

This PR is based on an alternative solution [posted here](https://stackoverflow.com/questions/27378143/qt-5-produce-random-attribute-order-in-xml), which generates the xml contents recursively generating elements for each node. 

This patch also adds a test for this fix.
