### PR TITLE
Set behaviortree_cpp_v3 library correctly for catkin build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,10 @@ if(catkin_FOUND)
   message(STATUS "------------------------------------------------")
 
   catkin_package(
-    INCLUDE_DIRS 
+    INCLUDE_DIRS
     LIBRARIES qt_node_editor
     CATKIN_DEPENDS behaviortree_cpp_v3
-    DEPENDS 
+    DEPENDS
     )
 endif(catkin_FOUND)
 #############################################################
@@ -124,8 +124,10 @@ SET(GROOT_DEPENDENCIES QtNodeEditor )
 
 if( catkin_FOUND )
     SET(GROOT_DEPENDENCIES ${GROOT_DEPENDENCIES} ${catkin_LIBRARIES} )
+    SET(BEHAVIORTREE_CPP_V3_LIB ${behaviortree_cpp_v3_LIBRARIES})
 else()
     SET(GROOT_DEPENDENCIES ${GROOT_DEPENDENCIES} behaviortree_cpp_v3 )
+    SET(BEHAVIORTREE_CPP_V3_LIB behaviortree_cpp_v3)
 endif()
 
 if( ZMQ_FOUND )
@@ -136,7 +138,7 @@ target_link_libraries(behavior_tree_editor ${GROOT_DEPENDENCIES} )
 
 
 add_executable(Groot ./bt_editor/main.cpp  ${RESOURCE_FILES})
-target_link_libraries(Groot behavior_tree_editor behaviortree_cpp_v3 )
+target_link_libraries(Groot behavior_tree_editor ${BEHAVIORTREE_CPP_V3_LIB})
 
 add_subdirectory(test)
 
@@ -150,13 +152,13 @@ else()
     set( GROOT_LIB_DESTINATION   lib )
     set( GROOT_INC_DESTINATION   include )
     set( GROOT_BIN_DESTINATION   bin )
-    
+
     INSTALL( FILES ${CMAKE_CURRENT_SOURCE_DIR}/groot_icon.png
 			 DESTINATION share/icons/hicolor/256x256)
-			 
+
 	INSTALL( FILES ${CMAKE_CURRENT_SOURCE_DIR}/Groot.desktop
 			 DESTINATION share/applications)
-    
+
 endif()
 
 INSTALL(TARGETS Groot RUNTIME DESTINATION ${GROOT_BIN_DESTINATION} )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,7 +14,7 @@ ENABLE_TESTING()
 
 function(CompileTest name)
     add_executable(${name} ${name}.cpp groot_test_base.cpp ${RESOURCE_FILES} )
-    target_link_libraries(${name} PRIVATE Qt5::Gui Qt5::Test behavior_tree_editor behaviortree_cpp_v3)
+    target_link_libraries(${name} PRIVATE Qt5::Gui Qt5::Test behavior_tree_editor ${BEHAVIORTREE_CPP_V3_LIB})
     add_test(${name} COMMAND ${name})
 endfunction()
 


### PR DESCRIPTION
Link against behaviortree_cpp_v3 library correctly when building with catkin