### PR TITLE
fix "renaming" subtree with the same previous name

### DIFF
--- a/bt_editor/mainwindow.cpp
+++ b/bt_editor/mainwindow.cpp
@@ -147,6 +147,9 @@ MainWindow::MainWindow(GraphicMode initial_mode, QWidget *parent) :
     connect( _editor_widget, &SidepanelEditor::renameSubtree,
              this, [this](QString prev_ID, QString new_ID)
     {
+        if (prev_ID == new_ID)
+            return;
+            
         for (int index = 0; index < ui->tabWidget->count(); index++)
         {
             if( ui->tabWidget->tabText(index) == prev_ID)


### PR DESCRIPTION
System crashes when edit tree with the same name because of : 
`_tab_info.erase( prev_ID )`

It also solves the problem in issue #43 

-----------

### **How to test**
Test 1:
- Add SubTree with Name T 
- right-click on T and Edit (on Palette), 
- Do not change anything and press "OK". 
- Try to expand the Tree (it crashes before)

Test 2:
- Add SubTree with Name T 
- right-click on T and Edit (on Palette),
- Add Port and Ok.
- Expand it (it crashes before) 