### PR TITLE
Reload tree

### DIFF
--- a/bt_editor/sidepanel_monitor.cpp
+++ b/bt_editor/sidepanel_monitor.cpp
@@ -45,6 +45,7 @@ void SidepanelMonitor::on_timer()
             ui->labelCount->setText( QString("Messages received: %1").arg(_msg_count) );
 
             const char* buffer = reinterpret_cast<const char*>(msg.data());
+	    
             const uint32_t header_size = flatbuffers::ReadScalar<uint32_t>( buffer );
             const uint32_t num_transitions = flatbuffers::ReadScalar<uint32_t>( &buffer[4+header_size] );
 
@@ -70,6 +71,7 @@ void SidepanelMonitor::on_timer()
 		    ui->lineEdit->setDisabled(false);
 		    _timer->stop();
 		    connectionUpdate(false);
+		    return;
 		}
 	    }
 


### PR DESCRIPTION
I have been working with Groot and ROS Navigation2 (modified and publishing ZMQ logger) and had a problem with the monitoring view.

crash reproduction procedure
----
1. createTreeFromFile and publish
2. monitor (this is okay)
3. second createTreeFromFile and publish, then crash

problem
----
It tries to find nodes matching to the UIDs in flatbuffer but it needs to know the new tree

fixed strategy
----
1. check all UIDs in flatbuffer if monitor already know the UIDs
2. if not, reload tree from the server and update status


