### PR TITLE
Feature: Include Path in XML

### DIFF
--- a/bt_editor/mainwindow.h
+++ b/bt_editor/mainwindow.h
@@ -45,7 +45,7 @@ public:
     explicit MainWindow(GraphicMode initial_mode, QWidget *parent = nullptr);
     ~MainWindow() override;
 
-    void loadFromXML(const QString &xml_text);
+    void loadFromXML(const QString &xml_text, bool main = true);
 
     QString saveToXML() const ;
 

--- a/test_data/include_path_test/main.xml
+++ b/test_data/include_path_test/main.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root main_tree_to_execute = "MainTree" >
+	<!-- The include paths need to be adapted to the ones required by the interpreter -->
+	<include path = "variant1.xml"/>
+	<BehaviorTree ID="MainTree">
+		<Sequence name="root_sequence">
+			<SetBlackboard output_key = "vp_velocity" value = "3"/>
+			<Action ID="SaySomething"   name="action_hello" message="Hello"/>
+			<Sequence>
+				<SubTree ID = "Variant1"/>
+				<SubTree ID = "Variant2"/> 
+				<AlwaysSuccess/> 
+			</Sequence >			
+			<Action ID="OpenGripper"    name="open_gripper"/>
+			<Action ID="ApproachObject" name="approach_object" velocity="{vp_velocity}"/>
+			<Action ID="CloseGripper"   name="close_gripper"/>
+			<Action ID="SaySomething"   name="action_bye" message="Bye"/>
+        </Sequence>
+     </BehaviorTree>
+</root >

--- a/test_data/include_path_test/variant1.xml
+++ b/test_data/include_path_test/variant1.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+ <include path = "variant2.xml"/>
+ <BehaviorTree ID="Variant1" >
+    <Sequence>
+       <Action ID="DisplayMessage" name="show_msg" message="{greetings}" output ="{answer}"/>
+       <SubTree ID = "Variant2"/> 
+    </Sequence>
+ </BehaviorTree>
+</root>

--- a/test_data/include_path_test/variant2.xml
+++ b/test_data/include_path_test/variant2.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+ <BehaviorTree ID="Variant2">
+    <Sequence>
+       <Action ID="PlayWarningBeep" name="play_sound" sound="WarningBeep"/>
+    </Sequence>
+ </BehaviorTree>
+</root>


### PR DESCRIPTION
## Description
With this new feature. the user can include path in the XML file for subtrees.
Absolute or relative paths.
Please see the example on "How to test".

## How to test
Load the XML file in:
test_data/include_path_test/main.xml
All files in the folder should be opened, because of the recursive call.