### PR TITLE
Feature idle trail

### DIFF
--- a/bt_editor/mainwindow.cpp
+++ b/bt_editor/mainwindow.cpp
@@ -147,6 +147,9 @@ MainWindow::MainWindow(GraphicMode initial_mode, QWidget *parent) :
     connect( _editor_widget, &SidepanelEditor::renameSubtree,
              this, [this](QString prev_ID, QString new_ID)
     {
+        if (prev_ID == new_ID)
+            return;
+            
         for (int index = 0; index < ui->tabWidget->count(); index++)
         {
             if( ui->tabWidget->tabText(index) == prev_ID)

--- a/bt_editor/mainwindow.cpp
+++ b/bt_editor/mainwindow.cpp
@@ -1457,10 +1457,35 @@ bool MainWindow::SavedState::operator ==(const MainWindow::SavedState &other) co
     return true;
 }
 
+void MainWindow::resetTreeStyle(AbsBehaviorTree &tree){
+    //printf("resetTreeStyle\n");
+    QtNodes::NodeStyle  node_style;
+    QtNodes::ConnectionStyle conn_style;
+
+    for(auto abs_node: tree.nodes()){
+        auto gui_node = abs_node.graphic_node;
+
+        gui_node->nodeDataModel()->setNodeStyle( node_style );
+        gui_node->nodeGraphicsObject().update();
+
+        const auto& conn_in = gui_node->nodeState().connections(PortType::In, 0 );
+        if(conn_in.size() == 1)
+        {
+            auto conn = conn_in.begin()->second;
+            conn->setStyle( conn_style );
+            conn->connectionGraphicsObject().update();
+        }
+    }
+}
+
 void MainWindow::onChangeNodesStatus(const QString& bt_name,
                                      const std::vector<std::pair<int, NodeStatus> > &node_status)
 {
     auto tree = BuildTreeFromScene( getTabByName(bt_name)->scene() );
+
+    std::vector<NodeStatus> vec_last_status(tree.nodesCount());
+
+    // printf("---\n");
 
     for (auto& it: node_status)
     {
@@ -1468,10 +1493,17 @@ void MainWindow::onChangeNodesStatus(const QString& bt_name,
         const NodeStatus status = it.second;
         auto& abs_node = tree.nodes().at(index);
 
+        // printf("%3d: %d, %s\n", index, (int)it.second, abs_node.instance_name.toStdString().c_str());
+
+        if(index == 1 && it.second == NodeStatus::RUNNING)
+            resetTreeStyle(tree);
+
         auto gui_node = abs_node.graphic_node;
-        auto style = getStyleFromStatus( status );
+        auto style = getStyleFromStatus( status, vec_last_status[index] );
         gui_node->nodeDataModel()->setNodeStyle( style.first );
         gui_node->nodeGraphicsObject().update();
+
+        vec_last_status[index] = status;
 
         const auto& conn_in = gui_node->nodeState().connections(PortType::In, 0 );
         if(conn_in.size() == 1)

--- a/bt_editor/mainwindow.h
+++ b/bt_editor/mainwindow.h
@@ -57,6 +57,8 @@ public:
 
     const NodeModels &registeredModels() const;
 
+    void resetTreeStyle(AbsBehaviorTree &tree);
+
 public slots:
 
     void onAutoArrange();

--- a/bt_editor/sidepanel_replay.h
+++ b/bt_editor/sidepanel_replay.h
@@ -69,6 +69,8 @@ private:
         double timestamp;
         NodeStatus prev_status;
         NodeStatus status;
+        bool is_tree_restart;
+        int nearest_restart_transition_index;
     };
     std::vector<Transition> _transitions;
     std::vector< std::pair<double,int>> _timepoint;

--- a/bt_editor/utils.cpp
+++ b/bt_editor/utils.cpp
@@ -456,25 +456,54 @@ BuildTreeFromFlatbuffers(const Serialization::BehaviorTree *fb_behavior_tree)
 }
 
 std::pair<QtNodes::NodeStyle, QtNodes::ConnectionStyle>
-getStyleFromStatus(NodeStatus status)
+getStyleFromStatus(NodeStatus status, NodeStatus prev_status)
 {
     QtNodes::NodeStyle  node_style;
     QtNodes::ConnectionStyle conn_style;
 
+    float penWidth = 3.0;
+
     conn_style.HoveredColor = Qt::transparent;
+
+    //printf("status=%d, old=%d\n", status, prev_status);
 
     if( status == NodeStatus::IDLE )
     {
+        if(prev_status != NodeStatus::IDLE){
+            node_style.PenWidth *= penWidth;
+            node_style.HoveredPenWidth = node_style.PenWidth;
+
+            if( prev_status == NodeStatus::SUCCESS )
+            {
+                node_style.NormalBoundaryColor =
+                        node_style.ShadowColor = QColor(100, 150, 100);
+                conn_style.NormalColor = node_style.NormalBoundaryColor;
+            }
+            else if( prev_status == NodeStatus::RUNNING )
+            {
+                node_style.NormalBoundaryColor =
+                        node_style.ShadowColor =  QColor(150, 130, 40);
+                conn_style.NormalColor = node_style.NormalBoundaryColor;
+            }
+            else if( prev_status == NodeStatus::FAILURE )
+            {
+                node_style.NormalBoundaryColor =
+                        node_style.ShadowColor = QColor(150, 80, 80);
+                conn_style.NormalColor = node_style.NormalBoundaryColor;
+            }
+        }
+
         return {node_style, conn_style};
     }
 
-    node_style.PenWidth *= 3.0;
+    node_style.PenWidth *= penWidth;
     node_style.HoveredPenWidth = node_style.PenWidth;
 
     if( status == NodeStatus::SUCCESS )
     {
         node_style.NormalBoundaryColor =
                 node_style.ShadowColor = QColor(51, 200, 51);
+                node_style.ShadowColor = QColor(51, 250, 51);
         conn_style.NormalColor = node_style.NormalBoundaryColor;
     }
     else if( status == NodeStatus::RUNNING )

--- a/bt_editor/utils.h
+++ b/bt_editor/utils.h
@@ -27,7 +27,7 @@ AbsBehaviorTree BuildTreeFromXML(const QDomElement &bt_root, const NodeModels &m
 void NodeReorder(QtNodes::FlowScene &scene, AbsBehaviorTree &abstract_tree );
 
 std::pair<QtNodes::NodeStyle, QtNodes::ConnectionStyle>
- getStyleFromStatus(NodeStatus status);
+getStyleFromStatus(NodeStatus status, NodeStatus prev_status);
 
 QtNodes::Node* GetParentNode(QtNodes::Node* node);
 


### PR DESCRIPTION
If tree don't have any running node, we can see nothing about deep nodes in monitor mode, only upper node state. 
We can avoid the problem by increasing tick frequency, but it requires more computational resourses.

![333](https://user-images.githubusercontent.com/8415489/78562152-99559c80-7821-11ea-9b80-ac47c2410757.png)

My solution is adding graphical styles for IDLE nodes, that was SUCCESS or FAILURE at current tick. 
Gray-green - it is a IDLE status, that was SUCCESS in the past of the tick.
Gray-red - IDLE, that was FAILURE.
I.e. nodes stores it's last previous state and shows it, if current state is IDLE.

![111](https://user-images.githubusercontent.com/8415489/78557419-6d361d80-7819-11ea-8bc1-2f27a3c74efc.png)

It is also works well with RUNNING status

![222](https://user-images.githubusercontent.com/8415489/78562419-fbae9d00-7821-11ea-9033-3482533f1cd5.png)

 and in replay mode

![Screenshot from 2020-04-06 16-07-13](https://user-images.githubusercontent.com/8415489/78562430-ffdaba80-7821-11ea-9d5e-7596541fdb07.png)
