### PR TITLE
change tooltip color to make it differ from background and visible

### DIFF
--- a/bt_editor/models/BehaviorTreeNodeModel.cpp
+++ b/bt_editor/models/BehaviorTreeNodeModel.cpp
@@ -130,6 +130,7 @@ BehaviorTreeDataModel::BehaviorTreeDataModel(const NodeModel &model):
                     { emit this->portValueDoubleChicked(nullptr); });
 
             QLabel* form_label  =  new QLabel( label, _params_widget );
+            form_label->setStyleSheet("QToolTip {color: black;}");
             form_label->setToolTip( description );
 
             form_field->setMinimumWidth(DEFAULT_FIELD_WIDTH);


### PR DESCRIPTION
Can't see text of port description tooltip. Changing text style solved the problem.

(don't know how to make screenshort with tooltip)
![descr](https://user-images.githubusercontent.com/8415489/78574277-741d5a00-7832-11ea-814c-746a4af81ec8.png)
