### PR TITLE
Add build dependencies, Format package.xml, closes #77

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,16 +10,22 @@
   <!-- One license tag required, multiple allowed, one license per tag -->
   <license>MIT</license>
 
-    <buildtool_depend>catkin</buildtool_depend>
-    <build_depend>cmake_modules</build_depend>
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>cmake_modules</build_depend>
 
-    <build_depend>pluginlib</build_depend>
-    <build_depend>roscpp</build_depend>
-    <build_depend>behaviortree_cpp_v3</build_depend>
+  <build_depend>pluginlib</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>behaviortree_cpp_v3</build_depend>
+  <build_depend>qtbase5-dev</build_depend>
+  <build_depend>libqt5-svg-dev</build_depend>
+  <build_depend>libqt5-opengl-dev</build_depend>
+  <build_depend>qttools5-dev-tools</build_depend>
+  <build_depend>libdw-dev</build_depend>
+  <build_depend>libzmq3-dev</build_depend>
 
-    <run_depend>pluginlib</run_depend>
-    <run_depend>roscpp</run_depend>
-    <run_depend>behaviortree_cpp_v3</run_depend>
+  <run_depend>pluginlib</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>behaviortree_cpp_v3</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
Add the following dependency names of ROS index:
- qtbase5-dev https://index.ros.org/d/qtbase5-dev/
- libqt5-svg-dev https://index.ros.org/d/libqt5-svg-dev/
- libqt5-opengl-dev https://index.ros.org/d/libqt5-opengl-dev/
- qttools5-dev-tools https://index.ros.org/d/qttools5-dev-tools/
- libdw-dev https://index.ros.org/d/libdw-dev/
- libzmq3-dev https://index.ros.org/d/libzmq3-dev/

This adds all dependencies mentioned in `Readme.md` and `.travis.yaml`