### PR TITLE
proposed fix for #87

### DIFF
--- a/bt_editor/sidepanel_editor.cpp
+++ b/bt_editor/sidepanel_editor.cpp
@@ -190,6 +190,16 @@ void SidepanelEditor::onContextMenu(const QPoint& pos)
         return;
     }
 
+    // Loop through the category items and prevent the right click
+    // menu from showing for any of the items
+    for (const auto& it : _tree_view_category_items)
+    {
+        const auto category_item = it.second;
+        if( category_item == selected_item ) {
+            return;
+        }
+    }
+
     QMenu menu(this);
 
     QAction* edit   = menu.addAction("Edit");


### PR DESCRIPTION
I didn't see any QT flags for disabling the context menu, so on each menu click I just loop through _tree_view_category_items and check if the value is found.  If found I block the context menu.

Note I am branching from e4863d5 as this is the latest version that builds (for travis)