### PR TITLE
Fix crash on node edit

### DIFF
--- a/bt_editor/custom_node_dialog.cpp
+++ b/bt_editor/custom_node_dialog.cpp
@@ -27,6 +27,9 @@ CustomNodeDialog::CustomNodeDialog(const NodeModels &models,
     restoreGeometry(settings.value("CustomNodeDialog/geometry").toByteArray());
     ui->tableWidget->horizontalHeader()->restoreState( settings.value("CustomNodeDialog/header").toByteArray() );
 
+    QRegExp rx("\\w+");
+    _validator = new QRegExpValidator(rx, this);
+
     if( to_edit.isEmpty() == false)
     {
         auto model_it = models.find(to_edit);
@@ -87,10 +90,6 @@ CustomNodeDialog::CustomNodeDialog(const NodeModels &models,
 
     connect( ui->lineEdit, &QLineEdit::textChanged,
              this, &CustomNodeDialog::checkValid );
-
-    QRegExp rx("\\w+");
-    _validator = new QRegExpValidator(rx, this);
-
 
     checkValid();
 }


### PR DESCRIPTION
Fix for issue #99

**Description**
---
When the node is edit mode, depending on the node type the combo box index is set and the curentIndexChanged callback where `checkValid()` is called. Inside `checkValid()` node name is validated using RegExpValidator `_validator` which is created later in the constructor using the `new` operator.

**Fix**
---
Reordered QRegExpValidator so that it is created before the edit logic is executed.

**Tested on**
---
Ubuntu 20, Master branch of Groot and BehaviorTree.CPP