### PR TITLE
Fix for Issue #101

### DIFF
--- a/bt_editor/graphic_container.cpp
+++ b/bt_editor/graphic_container.cpp
@@ -352,6 +352,13 @@ void GraphicContainer::onNodeCreated(Node &node)
 
 void GraphicContainer::onNodeContextMenu(Node &node, const QPointF &)
 {
+    // only allow context menu in editor mode
+    auto main_win = dynamic_cast<MainWindow*>( parent() );
+    if( main_win->getGraphicMode() != GraphicMode::EDITOR )
+    {
+        return;
+    }
+
     QMenu* node_menu = new QMenu(_view);
     //--------------------------------
     createMorphSubMenu(node, node_menu);
@@ -566,6 +573,13 @@ void GraphicContainer::insertNodeInConnection(Connection &connection, QString no
 
 void GraphicContainer::onConnectionContextMenu(QtNodes::Connection &connection, const QPointF&)
 {
+    // only allow connection context menu in editor mode
+    auto main_win = dynamic_cast<MainWindow*>( parent() );
+    if( main_win->getGraphicMode() != GraphicMode::EDITOR )
+    {
+        return;
+    }
+
     QMenu* conn_menu = new QMenu(_view);
 
     auto categories = {"Control", "Decorator"};

--- a/bt_editor/mainwindow.cpp
+++ b/bt_editor/mainwindow.cpp
@@ -1675,3 +1675,9 @@ void MainWindow::on_actionReportIssue_triggered()
                          QMessageBox::Ok);
     QDesktopServices::openUrl(QUrl(url));
 }
+
+// returns the current graphic mode
+GraphicMode MainWindow::getGraphicMode(void) const
+{
+    return _current_mode;
+}

--- a/bt_editor/mainwindow.h
+++ b/bt_editor/mainwindow.h
@@ -59,6 +59,8 @@ public:
 
     void resetTreeStyle(AbsBehaviorTree &tree);
 
+    GraphicMode getGraphicMode(void) const;
+
 public slots:
 
     void onAutoArrange();

--- a/bt_editor/mainwindow.h
+++ b/bt_editor/mainwindow.h
@@ -132,11 +132,13 @@ private slots:
 
     void on_actionReportIssue_triggered();
 
+public:
+
+    void lockEditing(const bool locked);
+
 private:
 
     void updateCurrentMode();
-
-    void lockEditing(const bool locked);
 
     bool eventFilter(QObject *obj, QEvent *event) override;
 

--- a/bt_editor/sidepanel_monitor.cpp
+++ b/bt_editor/sidepanel_monitor.cpp
@@ -7,6 +7,7 @@
 #include <QLabel>
 #include <QDebug>
 
+#include "mainwindow.h"
 #include "utils.h"
 
 SidepanelMonitor::SidepanelMonitor(QWidget *parent) :
@@ -15,7 +16,8 @@ SidepanelMonitor::SidepanelMonitor(QWidget *parent) :
     _zmq_context(1),
     _zmq_subscriber(_zmq_context, ZMQ_SUB),
     _connected(false),
-    _msg_count(0)
+    _msg_count(0),
+    _parent(parent)
 {
     ui->setupUi(this);
     _timer = new QTimer(this);
@@ -104,6 +106,10 @@ void SidepanelMonitor::on_timer()
 
             // update the graphic part
             emit changeNodeStyle( "BehaviorTree", node_status );
+
+            // lock editing of nodes
+            auto main_win = dynamic_cast<MainWindow*>( _parent );
+            main_win->lockEditing(true);
         }
     }
     catch( zmq::error_t& err)

--- a/bt_editor/sidepanel_monitor.h
+++ b/bt_editor/sidepanel_monitor.h
@@ -54,6 +54,8 @@ private:
 
     bool getTreeFromServer();
 
+    QWidget *_parent;
+
 };
 
 #endif // SIDEPANEL_MONITOR_H

--- a/bt_editor/sidepanel_replay.cpp
+++ b/bt_editor/sidepanel_replay.cpp
@@ -14,13 +14,15 @@
 #include <QMessageBox>
 
 #include "bt_editor_base.h"
+#include "mainwindow.h"
 #include "utils.h"
 
 
 SidepanelReplay::SidepanelReplay(QWidget *parent) :
     QFrame(parent),
     ui(new Ui::SidepanelReplay),
-    _prev_row(-1)
+    _prev_row(-1),
+    _parent(parent)
 {
     ui->setupUi(this);
 
@@ -271,6 +273,11 @@ void SidepanelReplay::loadLog(const QByteArray &content)
     _timepoint.clear();
     _prev_row = -1;
     updateTableModel(_loaded_tree);
+
+
+    // We need to lock the nodes after they are loaded
+    auto main_win = dynamic_cast<MainWindow*>( _parent );
+    main_win->lockEditing(true);
 }
 
 

--- a/bt_editor/sidepanel_replay.h
+++ b/bt_editor/sidepanel_replay.h
@@ -89,6 +89,8 @@ private:
     AbsBehaviorTree _loaded_tree;
 
     void updateTableModel(const AbsBehaviorTree &tree);
+
+    QWidget *_parent;
 };
 
 #endif // SIDEPANEL_REPLAY_H


### PR DESCRIPTION
I was able to fix the majority of edits which cause crashes in log replay and monitor mode.  Not sure if this is the correct way to lock nodes. I had to call `dynamic_cast<MainWindow*>` in a few places to get this to work