### PR TITLE
Solve segfaults caused by expanding / refreshing invalid subtrees

### DIFF
--- a/bt_editor/mainwindow.cpp
+++ b/bt_editor/mainwindow.cpp
@@ -1041,6 +1041,16 @@ QtNodes::Node* MainWindow::subTreeExpand(GraphicContainer &container,
     if( option == SUBTREE_EXPAND && subtree_model->expanded() == false)
     {
         auto subtree_container = getTabByName(subtree_name);
+
+        // Prevent expansion of invalid subtree
+        if( !subtree_container->containsValidTree() )
+        {
+            QMessageBox::warning(this, tr("Oops!"),
+                                 tr("Invalid SubTree. Can not expand SubTree."),
+                                 QMessageBox::Cancel);
+            return &node;
+        }
+
         auto abs_subtree = BuildTreeFromScene( subtree_container->scene() );
 
         subtree_model->setExpanded(true);
@@ -1361,6 +1371,16 @@ void MainWindow::refreshExpandedSubtrees()
 
     for (auto subtree_node: subtree_nodes)
     {
+        // expanded subtrees may have become invalid
+        // collapse invalid subtrees before refreshing them
+        auto subtree_model = dynamic_cast<SubtreeNodeModel*>(subtree_node->nodeDataModel());
+        const QString& subtree_name = subtree_model->registrationName();
+        auto subtree_container = getTabByName(subtree_name);
+        if ( subtree_model->expanded() && !subtree_container->containsValidTree() )
+        {
+            subTreeExpand( *container, *subtree_node, SUBTREE_COLLAPSE );
+        }
+
         subTreeExpand( *container, *subtree_node, SUBTREE_REFRESH );
     }
 }


### PR DESCRIPTION
Solves segfaults from #52 and #111 

One problem was caused by attempting to expand invalid subtrees, e.g., with an unconnected node. This change gives a popup message saying that this subtree can not be expanded.

Another problem was when a subtree was already expanded, and then modified into an invalid subtree, e.g., by removing an edge. Switching back to the tab with the expanded subtree triggered code to refresh the now invalid subtree leading to a segfault. This change collapses the subtree before refreshing it.