### PR TITLE
Fixed CMake command API error.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,7 +15,7 @@ ENABLE_TESTING()
 function(CompileTest name)
     add_executable(${name} ${name}.cpp groot_test_base.cpp ${RESOURCE_FILES} )
     target_link_libraries(${name} PRIVATE Qt5::Gui Qt5::Test behavior_tree_editor)
-    add_test(${name} COMMAND ${name})
+    add_test(NAME ${name} COMMAND ${name})
 endfunction()
 
 set(RESOURCE_FILES
@@ -27,4 +27,3 @@ set(RESOURCE_FILES
 
 CompileTest( editor_test )
 CompileTest( replay_test )
-


### PR DESCRIPTION
This fixed broken unit tests (at least on Ubuntu 20.04 using CMake 3.16.3) with the following output:

```bash
Unable to find executable: COMMAND
Unable to find executable: COMMAND
Errors while running CTest
```
I believe the change should be compatible with all recent version of CMake, though I have not broadly tested it.
