### PR TITLE
Cleaning up minor warnings

### DIFF
--- a/QtNodeEditor/src/NodeState.cpp
+++ b/QtNodeEditor/src/NodeState.cpp
@@ -48,7 +48,7 @@ NodeState::
 connections(PortType portType, PortIndex portIndex) const
 {
   auto const &connections = getEntries(portType);
-  if( portIndex < 0 || portIndex >= connections.size() )
+  if( portIndex < 0 || static_cast<unsigned long>(portIndex) >= connections.size() )
   {
     return NodeState::ConnectionPtrSet();
   }
@@ -139,4 +139,3 @@ resizing() const
 {
   return _resizing;
 }
-

--- a/bt_editor/sidepanel_monitor.cpp
+++ b/bt_editor/sidepanel_monitor.cpp
@@ -41,7 +41,7 @@ void SidepanelMonitor::on_timer()
 
     zmq::message_t msg;
     try{
-        while(  _zmq_subscriber.recv(&msg) )
+        while(  _zmq_subscriber.recv(msg) )
         {
             _msg_count++;
             ui->labelCount->setText( QString("Messages received: %1").arg(_msg_count) );
@@ -50,7 +50,7 @@ void SidepanelMonitor::on_timer()
 
             const uint32_t header_size = flatbuffers::ReadScalar<uint32_t>( buffer );
             const uint32_t num_transitions = flatbuffers::ReadScalar<uint32_t>( &buffer[4+header_size] );
-            
+
             std::vector<std::pair<int, NodeStatus>> node_status;
             // check uid in the index, if failed load tree from server
             try{
@@ -59,7 +59,7 @@ void SidepanelMonitor::on_timer()
                     const uint16_t uid = flatbuffers::ReadScalar<uint16_t>(&buffer[offset]);
                     _uid_to_index.at(uid);
                 }
-                
+
                 for(size_t t=0; t < num_transitions; t++)
                 {
                     size_t offset = 8 + header_size + 12*t;
@@ -130,10 +130,10 @@ bool SidepanelMonitor::getTreeFromServer()
         int timeout_ms = 1000;
         zmq_client.setsockopt(ZMQ_RCVTIMEO,&timeout_ms, sizeof(int) );
 
-        zmq_client.send(request);
+        zmq_client.send(request, zmq::send_flags::none);
 
-        bool received = zmq_client.recv(&reply);
-        if( ! received )
+        auto bytes_received  = zmq_client.recv(reply, zmq::recv_flags::none);
+        if( *bytes_received == 0 )
         {
             return false;
         }

--- a/bt_editor/sidepanel_monitor.cpp
+++ b/bt_editor/sidepanel_monitor.cpp
@@ -133,7 +133,7 @@ bool SidepanelMonitor::getTreeFromServer()
         zmq_client.send(request, zmq::send_flags::none);
 
         auto bytes_received  = zmq_client.recv(reply, zmq::recv_flags::none);
-        if( *bytes_received == 0 )
+        if( !bytes_received || *bytes_received == 0 )
         {
             return false;
         }


### PR DESCRIPTION
This cleans up these gcc warnings, mostly related to moving to the newer API of zmq vs. deprecated function use:

```bash
NodeState.cpp:51:34: warning: comparison of integer expressions of different signedness: ‘QtNodes::PortIndex’ {aka ‘int’} and ‘std::vector<std::unordered_map<QUuid, QtNodes::Connection*> >::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
   51 |   if( portIndex < 0 || portIndex >= connections.size() )
sidepanel_monitor.cpp:42:42: warning: ‘bool zmq::detail::socket_base::recv(zmq::message_t*, int)’ is deprecated: from 4.3.1, use recv taking a reference to message_t and recv_flags [-Wdeprecated-declarations]
   42 |         while(  _zmq_subscriber.recv(&msg) )
sidepanel_monitor.cpp:1:
/usr/include/zmq.hpp:1407:10: note: declared here
 1407 |     bool recv(message_t *msg_, int flags_ = 0)
sidepanel_monitor.cpp:127:32: warning: ‘bool zmq::detail::socket_base::send(zmq::message_t&, int)’ is deprecated: from 4.3.1, use send taking message_t and send_flags [-Wdeprecated-declarations]
  127 |         zmq_client.send(request);
sidepanel_monitor.cpp:1:
/usr/include/zmq.hpp:1326:10: note: declared here
 1326 |     bool send(message_t &msg_,
sidepanel_monitor.cpp:129:47: warning: ‘bool zmq::detail::socket_base::recv(zmq::message_t*, int)’ is deprecated: from 4.3.1, use recv taking a reference to message_t and recv_flags [-Wdeprecated-declarations]
  129 |         bool received = zmq_client.recv(&reply);
sidepanel_monitor.cpp:1:
/usr/include/zmq.hpp:1407:10: note: declared here
 1407 |     bool recv(message_t *msg_, int flags_ = 0)
```