### PR TITLE
added a check for catkin similar to ament to fix colcon on ROS1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 
 #############################################################
 find_package(ament_cmake QUIET)
+find_package(catkin QUIET)
 if(ament_cmake_FOUND)
   find_package(behaviortree_cpp_v3 REQUIRED)
 
@@ -30,7 +31,7 @@ if(ament_cmake_FOUND)
   message(STATUS "------------------------------------------------")
   message(STATUS "BehaviourTreeEditor is being built using AMENT.")
   message(STATUS "------------------------------------------------")
-elseif( CATKIN_DEVEL_PREFIX OR CATKIN_BUILD_BINARY_PACKAGE)
+elseif(catkin_FOUND OR CATKIN_DEVEL_PREFIX OR CATKIN_BUILD_BINARY_PACKAGE )
 # http://answers.ros.org/question/230877/optionally-build-a-package-with-catkin/
   set(catkin_FOUND 1)
   # add_definitions( -DUSING_ROS )


### PR DESCRIPTION
When compiling on ROS1 but using colcon, catkin was not being detected.

This adds a check for catkin similar to the way it's done for ament in addition to the other checks.