### PR TITLE
fix build on x64-windows with msvc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /build*
 /test_data/*_test.xml
 /test/CMakeLists.txt.user
+/.vs
+/out

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif()
 
+add_definitions("/EHsc")
+
 #############################################################
 find_package(ament_cmake QUIET)
 if(ament_cmake_FOUND)
@@ -140,11 +142,6 @@ endif()
 
 QT5_WRAP_UI(FORMS_HEADERS ${FORMS_UI})
 
-add_library(behavior_tree_editor SHARED
-    ${APP_CPPS}
-    ${FORMS_HEADERS}
-)
-
 SET(GROOT_DEPENDENCIES QtNodeEditor )
 
 if(ament_cmake_FOUND)
@@ -159,11 +156,8 @@ if( ZMQ_FOUND )
     SET(GROOT_DEPENDENCIES ${GROOT_DEPENDENCIES} zmq)
 endif()
 
-target_link_libraries(behavior_tree_editor ${GROOT_DEPENDENCIES} )
-
-
-add_executable(Groot ./bt_editor/main.cpp  ${RESOURCE_FILES})
-target_link_libraries(Groot behavior_tree_editor )
+add_executable(Groot ./bt_editor/main.cpp ${APP_CPPS} ${FORMS_HEADERS} ${RESOURCE_FILES})
+target_link_libraries(Groot ${GROOT_DEPENDENCIES} )
 
 add_subdirectory(test)
 
@@ -190,12 +184,10 @@ else()
     
 endif()
 
-INSTALL(TARGETS behavior_tree_editor LIBRARY DESTINATION ${GROOT_LIB_DESTINATION} )
 INSTALL(TARGETS Groot RUNTIME DESTINATION ${GROOT_BIN_DESTINATION} )
 
 if(ament_cmake_FOUND)
   ament_export_include_directories(include)
   ament_export_dependencies(${GROOT_DEPENDENCIES} ${dependencies})
-  ament_export_libraries(behavior_tree_editor)
   ament_package()
 endif()


### PR DESCRIPTION
This porbably breaks other build configurations (?), but msvc works now.
Build was tested using VisualStudio's "Open Folder" option and using vcpkg to get the dependencies.

The reason for this fix:
During build of target "groot" there were errors about behavior_tree_editor.lib not being found.
It seems that target was not being exported correctly in this configuration (?).
This change removes the behavior_tree_editor target entirely to fix the build.
Also it sets the Compiler Flag "/EHsc" for all projects, to fix other build errors.

As already said, these changes probably break other stuff, but people who want to build the project on windows might find this pull request helpful as a reference.