### PR TITLE
Added check for nullptr when expanding SubTree

### DIFF
--- a/bt_editor/mainwindow.cpp
+++ b/bt_editor/mainwindow.cpp
@@ -1041,6 +1041,12 @@ QtNodes::Node* MainWindow::subTreeExpand(GraphicContainer &container,
     if( option == SUBTREE_EXPAND && subtree_model->expanded() == false)
     {
         auto subtree_container = getTabByName(subtree_name);
+        if (!subtree_container) {
+            QMessageBox::warning(this, tr("Oops!"),
+                                 tr("Couldn't get SubTree name from tabs and therefore can't expand."),
+                                 QMessageBox::Cancel);
+            return &node;
+        }
 
         // Prevent expansion of invalid subtree
         if( !subtree_container->containsValidTree() )


### PR DESCRIPTION
### Why
I kinda misunderstood  the whole SubTree building which resulted in me getting a segmentation fault. To make it easier to debug for others I added a warning dialog instead of crashing with a segfault.

### What
* Checked for nullptr after calling getTabByName in subTreeExpand and presenting warning dialog in case SubTree was not found.