### PR TITLE
Fix build on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,12 @@ else()
 endif()
 
 if( ZMQ_FOUND )
-    SET(GROOT_DEPENDENCIES ${GROOT_DEPENDENCIES} zmq)
+    if (APPLE)
+        find_package(cppzmq)
+        SET(GROOT_DEPENDENCIES ${GROOT_DEPENDENCIES} cppzmq)
+    else()
+        SET(GROOT_DEPENDENCIES ${GROOT_DEPENDENCIES} zmq)
+    endif()
 endif()
 
 target_link_libraries(behavior_tree_editor ${GROOT_DEPENDENCIES} )


### PR DESCRIPTION
On macOS, `zmq.hpp` comes from a separate package -- cppzmq. So in order to build on macOS, cppzmq needs to be linked in, not plain zmq. This change fixes this build on macOS (shouldn't impact anything else).