### PR TITLE
Change tab scope if the user double-clicks on a subtree

### DIFF
--- a/bt_editor/mainwindow.cpp
+++ b/bt_editor/mainwindow.cpp
@@ -146,6 +146,9 @@ MainWindow::MainWindow(GraphicMode initial_mode, QWidget *parent) :
         this->createTab(ID);
     });
 
+    connect(_editor_widget, &SidepanelEditor::setTabScope,
+            this, &MainWindow::onSubtreeSelected);
+
     connect( _editor_widget, &SidepanelEditor::renameSubtree,
              this, [this](QString prev_ID, QString new_ID)
     {
@@ -1704,4 +1707,16 @@ void MainWindow::on_actionReportIssue_triggered()
 GraphicMode MainWindow::getGraphicMode(void) const
 {
     return _current_mode;
+}
+
+void MainWindow::onSubtreeSelected(const QString& subtreeName)
+{
+    for (int i = 0; i < ui->tabWidget->tabBar()->count(); ++i)
+    {
+        if (ui->tabWidget->tabBar()->tabText(i) == subtreeName)
+        {
+            ui->tabWidget->tabBar()->setCurrentIndex(i);
+            return;
+        }
+    }
 }

--- a/bt_editor/mainwindow.h
+++ b/bt_editor/mainwindow.h
@@ -90,6 +90,8 @@ public slots:
 
     void on_actionSave_triggered();
 
+    void onSubtreeSelected(const QString& subtreeName);
+
     void on_splitter_splitterMoved(int pos = 0, int index = 0);
 
     void on_toolButtonReorder_pressed();

--- a/bt_editor/sidepanel_editor.cpp
+++ b/bt_editor/sidepanel_editor.cpp
@@ -29,6 +29,9 @@ SidepanelEditor::SidepanelEditor(QtNodes::DataModelRegistry *registry,
     connect( ui->paletteTreeWidget, &QWidget::customContextMenuRequested,
              this, &SidepanelEditor::onContextMenu);
 
+    connect(ui->paletteTreeWidget, &QTreeWidget::itemDoubleClicked,
+            this, &SidepanelEditor::onDoubleClick);
+
     auto table_header = ui->portsTableWidget->horizontalHeader();
 
     table_header->setSectionResizeMode(0, QHeaderView::ResizeToContents);
@@ -458,4 +461,20 @@ void SidepanelEditor::on_buttonLock_toggled(bool locked)
 
     ui->buttonLock->setIcon( locked ? icon_locked : icon_unlocked);
     updateTreeView();
+}
+
+void SidepanelEditor::onDoubleClick(QTreeWidgetItem *item, int column)
+{
+    QString selected_name = item->text(0);
+
+    if( ui->buttonLock->isChecked() ||
+        BuiltinNodeModels().count( selected_name ) != 0 )
+    {
+        return;
+    }
+
+    if (item->parent() && item->parent()->text(0) == "SubTree")
+    {
+        emit setTabScope(selected_name);
+    }
 }

--- a/bt_editor/sidepanel_editor.h
+++ b/bt_editor/sidepanel_editor.h
@@ -47,6 +47,8 @@ private slots:
 
     void on_buttonLock_toggled(bool checked);
 
+    void onDoubleClick(QTreeWidgetItem *item, int column);
+
 signals:
 
     void addNewModel(const NodeModel &new_model);
@@ -60,6 +62,8 @@ signals:
     void renameSubtree(QString prev_ID, QString new_ID);
 
     void destroySubtree(QString ID);
+
+    void setTabScope(const QString& subtreeName);
 
 private:
     Ui::SidepanelEditor *ui;


### PR DESCRIPTION
If there are many sub-trees in a given unified tree, it is difficult to navigate the tab bar. This PR adds functionality to change the active tab in the tab bar if a user double-clicks on the sub-tree in the side panel.