### PR TITLE
Better colors for palette items

### DIFF
--- a/bt_editor/sidepanel_editor.cpp
+++ b/bt_editor/sidepanel_editor.cpp
@@ -89,7 +89,10 @@ void SidepanelEditor::updateTreeView()
       item->setFont(0, font);
       item->setData(0, Qt::UserRole, ID);
 
-      item->setTextColor(0, is_editable ? Qt::blue : Qt::black);
+      if (is_editable)
+      {
+        item->setForeground(0, QBrush(Qt::blue));
+      }
     }
 
     ui->paletteTreeWidget->expandAll();

--- a/bt_editor/sidepanel_editor.cpp
+++ b/bt_editor/sidepanel_editor.cpp
@@ -91,7 +91,7 @@ void SidepanelEditor::updateTreeView()
 
       if (is_editable)
       {
-        item->setForeground(0, QBrush(Qt::blue));
+        item->setForeground(0, QBrush(QColor(70, 110, 154)));
       }
     }
 


### PR DESCRIPTION
Let default foreground colors for read-only items.
Better shade of blue for editable items.
Fixes #154.