### PR TITLE
fix node style for idle trail

### DIFF
--- a/bt_editor/graphic_container.cpp
+++ b/bt_editor/graphic_container.cpp
@@ -137,17 +137,16 @@ void GraphicContainer::lockSubtreeEditing(Node &root_node, bool locked, bool cha
             }
         }
         //--------------------------------
-        QtNodes::NodeStyle style;
-
         if( locked && change_style )
         {
+            QtNodes::NodeStyle style;
             style.GradientColor0.setBlue(120);
             style.GradientColor1.setBlue(100);
             style.GradientColor2.setBlue(90);
             style.GradientColor3.setBlue(90);
+            node->nodeDataModel()->setNodeStyle( style );
         }
         node->nodeGraphicsObject().setGeometryChanged();
-        node->nodeDataModel()->setNodeStyle( style );
         node->nodeGraphicsObject().update();
     }
 }


### PR DESCRIPTION
Idle trail styles was broken after 5deaf8533a33771712d4f8caee834e72bbcf9b52

before fix
![Screenshot from 2022-08-03 18-29-55](https://user-images.githubusercontent.com/8415489/182648382-eef469fd-b7b4-4a23-9d96-6fac8f6c23c2.png)

after fix
![Screenshot from 2022-08-03 18-30-35](https://user-images.githubusercontent.com/8415489/182648530-c485f9d9-971e-498a-a12f-5a9fd5ab9961.png)

I checked expanding, collapsing, adding subtrees in edit mode - seems no problems
