### PR TITLE
No need for line ending as the xml_text already contains it

### DIFF
--- a/bt_editor/mainwindow.cpp
+++ b/bt_editor/mainwindow.cpp
@@ -151,7 +151,7 @@ MainWindow::MainWindow(GraphicMode initial_mode, QWidget *parent) :
     {
         if (prev_ID == new_ID)
             return;
-            
+
         for (int index = 0; index < ui->tabWidget->count(); index++)
         {
             if( ui->tabWidget->tabText(index) == prev_ID)
@@ -647,7 +647,7 @@ void MainWindow::on_actionSave_triggered()
     QFile file(fileName);
     if (file.open(QIODevice::WriteOnly)) {
         QTextStream stream(&file);
-        stream << xml_text << endl;
+        stream << xml_text;
     }
 
     directory_path = QFileInfo(fileName).absolutePath();


### PR DESCRIPTION
I noticed the output xml always contained an extra (so two) line ending at the end of the file.

Since I have got a git-checker enabled for that, it anoyed me slightly. This fixes the double line-ending.