### PR TITLE
Fixed linking with BehaviorTrees already installed on the system.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,8 +83,8 @@ set(CATKIN_ENABLE_TESTING OFF CACHE BOOL "")
 
 if(NOT catkin_FOUND AND NOT ament_cmake_FOUND)
     # look for BehaviorTree.CPP on the system
-    find_package(BehaviorTreeV3)
-    if (NOT BehaviorTree_FOUND)
+    find_package(behaviortree_cpp_v3)
+    if (NOT behaviortree_cpp_v3_FOUND)
         # use git submodule only if you are not compiling with catkin
         add_subdirectory( depend/BehaviorTree.CPP )
         include_directories( depend/BehaviorTree.CPP/include )


### PR DESCRIPTION
I noticed that it was not possible to compile Groot if I didn't want to download BT as submodule, although I had it installed on the system. The name of the library was wrong in the find_package(...) command.