### PR TITLE
Fix references to RetryUntilSuccesful

### DIFF
--- a/bt_editor/resources/NodesStyle.json
+++ b/bt_editor/resources/NodesStyle.json
@@ -42,7 +42,7 @@
         "icon": ":/icons/svg/edit_list.svg"
     },
 
-    "RetryUntilSuccesful": {
+    "RetryUntilSuccessful": {
         "icon": ":/icons/svg/retry.svg"
     },
 

--- a/test_data/Simple.xml
+++ b/test_data/Simple.xml
@@ -2,9 +2,9 @@
     <!--  //////////  -->
     <BehaviorTree ID="DoorClosed">
         <Sequence name="door_closed_sequence">
-            <RetryUntilSuccesful num_attempts="4">
+            <RetryUntilSuccessful num_attempts="4">
                 <Action ID="OpenDoor"/>
-            </RetryUntilSuccesful>
+            </RetryUntilSuccessful>
         </Sequence>
     </BehaviorTree>
     <!--  //////////  -->

--- a/test_data/crossdoor_with_subtree.xml
+++ b/test_data/crossdoor_with_subtree.xml
@@ -6,9 +6,9 @@
             <Inverter>
                 <Condition ID="IsDoorOpen"/>
             </Inverter>
-            <RetryUntilSuccesful num_attempts="4">
+            <RetryUntilSuccessful num_attempts="4">
                 <Action ID="OpenDoor"/>
-            </RetryUntilSuccesful>
+            </RetryUntilSuccessful>
             <Action ID="PassThroughDoor"/>
             <Action ID="CloseDoor"/>
         </Sequence>

--- a/test_data/show_all.xml
+++ b/test_data/show_all.xml
@@ -10,11 +10,11 @@
                 </ReactiveFallback>
             </Fallback>
             <SequenceStar name="DoSequenceStar">
-                <RetryUntilSuccesful num_attempts="1">
+                <RetryUntilSuccessful num_attempts="1">
                     <BlackboardCheckString value_A="" return_on_mismatch="" value_B="">
                         <AlwaysSuccess/>
                     </BlackboardCheckString>
-                </RetryUntilSuccesful>
+                </RetryUntilSuccessful>
             </SequenceStar>
             <Inverter>
                 <ForceFailure>


### PR DESCRIPTION
Same as https://github.com/BehaviorTree/BehaviorTree.CPP/pull/308 but for Groot.

Fixes the `editor_test` and also adds the little icon as below:

before:
![retry_before](https://user-images.githubusercontent.com/20625381/190278125-76203047-3590-4348-9fa1-e48305fd8b62.png)
after:
![retry_after](https://user-images.githubusercontent.com/20625381/190278131-7a366017-c0a1-4211-9000-7403380d579d.png)
