### PR TITLE
Add publisher/server and autoconnect args to BT Monitor

### DIFF
--- a/bt_editor/main.cpp
+++ b/bt_editor/main.cpp
@@ -39,6 +39,19 @@ main(int argc, char *argv[])
                                    "Start in one of these modes: [editor,monitor,replay]",
                                    "mode");
     parser.addOption(mode_option);
+
+    QCommandLineOption pub_port_option(QStringList() << "publisher_port",
+                                       "Publisher port number (defaults to 1666)",
+                                       "publisher_port");
+    parser.addOption(pub_port_option);
+    QCommandLineOption srv_port_option(QStringList() << "server_port",
+                                       "Server port number (defaults to 1667)",
+                                       "server_port");
+    parser.addOption(srv_port_option);
+    QCommandLineOption autoconnect_option(QStringList() << "autoconnect",
+                                          "Autoconnect to monitor");
+    parser.addOption(autoconnect_option);
+
     parser.process( app );
 
     QFile styleFile( ":/stylesheet.qss" );
@@ -88,7 +101,14 @@ main(int argc, char *argv[])
             mode = dialog.getGraphicMode();
         }
 
-        MainWindow win( mode );
+        // Get the monitor options.
+        const QString monitor_pub_port = parser.value(pub_port_option);
+        const QString monitor_srv_port = parser.value(srv_port_option);
+        const bool monitor_autoconnect = parser.isSet(autoconnect_option);
+
+        // Start the main application.
+        MainWindow win( mode, monitor_pub_port, monitor_srv_port,
+                        monitor_autoconnect );
         win.show();
         return app.exec();
     }

--- a/bt_editor/main.cpp
+++ b/bt_editor/main.cpp
@@ -40,6 +40,10 @@ main(int argc, char *argv[])
                                    "mode");
     parser.addOption(mode_option);
 
+    QCommandLineOption address_option(QStringList() << "address",
+                                      "Address to connect to (defaults to localhost)",
+                                      "address");
+    parser.addOption(address_option);
     QCommandLineOption pub_port_option(QStringList() << "publisher_port",
                                        "Publisher port number (defaults to 1666)",
                                        "publisher_port");
@@ -102,13 +106,14 @@ main(int argc, char *argv[])
         }
 
         // Get the monitor options.
+        const QString monitor_address = parser.value(address_option);
         const QString monitor_pub_port = parser.value(pub_port_option);
         const QString monitor_srv_port = parser.value(srv_port_option);
         const bool monitor_autoconnect = parser.isSet(autoconnect_option);
 
         // Start the main application.
-        MainWindow win( mode, monitor_pub_port, monitor_srv_port,
-                        monitor_autoconnect );
+        MainWindow win( mode, monitor_address, monitor_pub_port,
+                        monitor_srv_port, monitor_autoconnect );
         win.show();
         return app.exec();
     }

--- a/bt_editor/mainwindow.cpp
+++ b/bt_editor/mainwindow.cpp
@@ -40,11 +40,18 @@ using QtNodes::FlowScene;
 using QtNodes::NodeGraphicsObject;
 using QtNodes::NodeState;
 
-MainWindow::MainWindow(GraphicMode initial_mode, QWidget *parent) :
-                                                                    QMainWindow(parent),
-                                                                    ui(new Ui::MainWindow),
-                                                                    _current_mode(initial_mode),
-                                                                    _current_layout(QtNodes::PortLayout::Vertical)
+MainWindow::MainWindow(GraphicMode initial_mode,
+                       const QString& monitor_pub_port,
+                       const QString& monitor_srv_port,
+                       const bool monitor_autoconnect,
+                       QWidget *parent) :
+    QMainWindow(parent),
+    ui(new Ui::MainWindow),
+    _current_mode(initial_mode),
+    _current_layout(QtNodes::PortLayout::Vertical),
+    _monitor_publisher_port(monitor_pub_port),
+    _monitor_server_port(monitor_srv_port),
+    _monitor_autoconnect(monitor_autoconnect)
 {
     ui->setupUi(this);
 
@@ -96,7 +103,8 @@ MainWindow::MainWindow(GraphicMode initial_mode, QWidget *parent) :
     ui->leftFrame->layout()->addWidget( _replay_widget );
 
 #ifdef ZMQ_FOUND
-    _monitor_widget = new SidepanelMonitor(this);
+    _monitor_widget = new SidepanelMonitor(
+        this, _monitor_publisher_port, _monitor_server_port);
     ui->leftFrame->layout()->addWidget( _monitor_widget );
 
     connect( ui->toolButtonConnect, &QToolButton::clicked,
@@ -104,6 +112,11 @@ MainWindow::MainWindow(GraphicMode initial_mode, QWidget *parent) :
 
     connect( _monitor_widget, &SidepanelMonitor::connectionUpdate,
             this, &MainWindow::onConnectionUpdate );
+
+    if (monitor_autoconnect) {
+        usleep(1e6);  // Add a slight delay
+        ui->toolButtonConnect->animateClick();
+    }
 #else
     ui->actionMonitor_mode->setVisible(false);
 #endif

--- a/bt_editor/mainwindow.cpp
+++ b/bt_editor/mainwindow.cpp
@@ -22,6 +22,7 @@
 #include <nodes/NodeData>
 #include <nodes/NodeStyle>
 #include <nodes/FlowView>
+#include <thread>
 
 #include "editor_flowscene.h"
 #include "utils.h"
@@ -41,6 +42,7 @@ using QtNodes::NodeGraphicsObject;
 using QtNodes::NodeState;
 
 MainWindow::MainWindow(GraphicMode initial_mode,
+                       const QString& monitor_address,
                        const QString& monitor_pub_port,
                        const QString& monitor_srv_port,
                        const bool monitor_autoconnect,
@@ -49,6 +51,7 @@ MainWindow::MainWindow(GraphicMode initial_mode,
     ui(new Ui::MainWindow),
     _current_mode(initial_mode),
     _current_layout(QtNodes::PortLayout::Vertical),
+    _monitor_address(monitor_address),
     _monitor_publisher_port(monitor_pub_port),
     _monitor_server_port(monitor_srv_port),
     _monitor_autoconnect(monitor_autoconnect)
@@ -104,7 +107,7 @@ MainWindow::MainWindow(GraphicMode initial_mode,
 
 #ifdef ZMQ_FOUND
     _monitor_widget = new SidepanelMonitor(
-        this, _monitor_publisher_port, _monitor_server_port);
+        this, _monitor_address, _monitor_publisher_port, _monitor_server_port);
     ui->leftFrame->layout()->addWidget( _monitor_widget );
 
     connect( ui->toolButtonConnect, &QToolButton::clicked,
@@ -113,7 +116,8 @@ MainWindow::MainWindow(GraphicMode initial_mode,
     connect( _monitor_widget, &SidepanelMonitor::connectionUpdate,
             this, &MainWindow::onConnectionUpdate );
 
-    if (monitor_autoconnect) {
+    if ( monitor_autoconnect )
+    {
         // If autoconnecting, increase the timeout to get the behavior tree to a
         // larger value. This only lasts for one "connect" before returning to
         // its default value.

--- a/bt_editor/mainwindow.cpp
+++ b/bt_editor/mainwindow.cpp
@@ -114,7 +114,11 @@ MainWindow::MainWindow(GraphicMode initial_mode,
             this, &MainWindow::onConnectionUpdate );
 
     if (monitor_autoconnect) {
-        usleep(1e6);  // Add a slight delay
+        // If autoconnecting, increase the timeout to get the behavior tree to a
+        // larger value. This only lasts for one "connect" before returning to
+        // its default value.
+        _monitor_widget->set_load_tree_timeout_ms(
+            _monitor_widget->_load_tree_autoconnect_timeout_ms);
         ui->toolButtonConnect->animateClick();
     }
 #else

--- a/bt_editor/mainwindow.h
+++ b/bt_editor/mainwindow.h
@@ -42,7 +42,11 @@ class MainWindow : public QMainWindow
                               SUBTREE_REFRESH};
 
 public:
-    explicit MainWindow(GraphicMode initial_mode, QWidget *parent = nullptr);
+    explicit MainWindow(GraphicMode initial_mode,
+                       const QString& monitor_pub_port = "",
+                       const QString& monitor_srv_port = "",
+                       const bool monitor_autoconnect = false,
+                       QWidget *parent = nullptr);
     ~MainWindow() override;
 
     void loadFromXML(const QString &xml_text);
@@ -197,7 +201,11 @@ private:
 #ifdef ZMQ_FOUND
     SidepanelMonitor* _monitor_widget;
 #endif
-    
+
+    QString _monitor_publisher_port;
+    QString _monitor_server_port;
+    bool _monitor_autoconnect;
+
     MainWindow::SavedState saveCurrentState();
     void clearUndoStacks();
 };

--- a/bt_editor/mainwindow.h
+++ b/bt_editor/mainwindow.h
@@ -43,10 +43,11 @@ class MainWindow : public QMainWindow
 
 public:
     explicit MainWindow(GraphicMode initial_mode,
-                       const QString& monitor_pub_port = "",
-                       const QString& monitor_srv_port = "",
-                       const bool monitor_autoconnect = false,
-                       QWidget *parent = nullptr);
+                        const QString& monitor_address = "",
+                        const QString& monitor_pub_port = "",
+                        const QString& monitor_srv_port = "",
+                        const bool monitor_autoconnect = false,
+                        QWidget *parent = nullptr);
     ~MainWindow() override;
 
     void loadFromXML(const QString &xml_text);
@@ -202,6 +203,7 @@ private:
     SidepanelMonitor* _monitor_widget;
 #endif
 
+    QString _monitor_address;
     QString _monitor_publisher_port;
     QString _monitor_server_port;
     bool _monitor_autoconnect;

--- a/bt_editor/sidepanel_monitor.cpp
+++ b/bt_editor/sidepanel_monitor.cpp
@@ -11,6 +11,7 @@
 #include "utils.h"
 
 SidepanelMonitor::SidepanelMonitor(QWidget *parent,
+                                   const QString &address,
                                    const QString &publisher_port,
                                    const QString &server_port) :
     QFrame(parent),
@@ -24,10 +25,16 @@ SidepanelMonitor::SidepanelMonitor(QWidget *parent,
     ui->setupUi(this);
     this->set_load_tree_timeout_ms(_load_tree_default_timeout_ms);
 
-    if (!publisher_port.isEmpty()) {
+    if ( !address.isEmpty() )
+    {
+        ui->lineEdit_address->setText(address);
+    }
+    if ( !publisher_port.isEmpty() )
+    {
         ui->lineEdit_publisher->setText(publisher_port);
     }
-    if (!server_port.isEmpty()) {
+    if ( !server_port.isEmpty() )
+    {
         ui->lineEdit_server->setText(server_port);
     }
 
@@ -107,7 +114,7 @@ void SidepanelMonitor::on_timer()
                 qDebug() << "Reload tree from server";
                 if( !getTreeFromServer() ) {
                     _connected = false;
-                    ui->lineEdit->setDisabled(false);
+                    ui->lineEdit_address->setDisabled(false);
                     _timer->stop();
                     connectionUpdate(false);
                     return;
@@ -198,11 +205,11 @@ void SidepanelMonitor::on_Connect()
 {
     if( !_connected )
     {
-        QString address = ui->lineEdit->text();
+        QString address = ui->lineEdit_address->text();
         if( address.isEmpty() )
         {
-            address = ui->lineEdit->placeholderText();
-            ui->lineEdit->setText(address);
+            address = ui->lineEdit_address->placeholderText();
+            ui->lineEdit_address->setText(address);
         }
 
         QString publisher_port = ui->lineEdit_publisher->text();
@@ -253,7 +260,7 @@ void SidepanelMonitor::on_Connect()
         if( !failed )
         {
             _connected = true;
-            ui->lineEdit->setDisabled(true);
+            ui->lineEdit_address->setDisabled(true);
             ui->lineEdit_publisher->setDisabled(true);
             _timer->start(_timer_period_ms);
             connectionUpdate(true);
@@ -267,7 +274,7 @@ void SidepanelMonitor::on_Connect()
     }
     else{
         _connected = false;
-        ui->lineEdit->setDisabled(false);
+        ui->lineEdit_address->setDisabled(false);
         ui->lineEdit_publisher->setDisabled(false);
         _timer->stop();
 

--- a/bt_editor/sidepanel_monitor.cpp
+++ b/bt_editor/sidepanel_monitor.cpp
@@ -10,7 +10,9 @@
 #include "mainwindow.h"
 #include "utils.h"
 
-SidepanelMonitor::SidepanelMonitor(QWidget *parent) :
+SidepanelMonitor::SidepanelMonitor(QWidget *parent,
+                                   const QString &publisher_port,
+                                   const QString &server_port) :
     QFrame(parent),
     ui(new Ui::SidepanelMonitor),
     _zmq_context(1),
@@ -20,8 +22,15 @@ SidepanelMonitor::SidepanelMonitor(QWidget *parent) :
     _parent(parent)
 {
     ui->setupUi(this);
-    _timer = new QTimer(this);
 
+    if (!publisher_port.isEmpty()) {
+        ui->lineEdit_publisher->setText(publisher_port);
+    }
+    if (!server_port.isEmpty()) {
+        ui->lineEdit_server->setText(server_port);
+    }
+
+    _timer = new QTimer(this);
     connect( _timer, &QTimer::timeout, this, &SidepanelMonitor::on_timer );
 }
 
@@ -187,7 +196,7 @@ bool SidepanelMonitor::getTreeFromServer()
 
 void SidepanelMonitor::on_Connect()
 {
-    if( !_connected)
+    if( !_connected )
     {
         QString address = ui->lineEdit->text();
         if( address.isEmpty() )

--- a/bt_editor/sidepanel_monitor.h
+++ b/bt_editor/sidepanel_monitor.h
@@ -15,12 +15,23 @@ class SidepanelMonitor : public QFrame
     Q_OBJECT
 
 public:
+    /// Timer period in milliseconds.
+    static constexpr int _timer_period_ms = 20;
+    /// Default timeout to get behavior tree, in milliseconds.
+    static constexpr int _load_tree_default_timeout_ms = 1000;
+    /// Timeout to get behavior tree during autoconnect, in milliseconds.
+    static constexpr int _load_tree_autoconnect_timeout_ms = 10000;
+
     explicit SidepanelMonitor(QWidget *parent = nullptr,
                               const QString &publisher_port = "",
                               const QString &server_port = "");
     ~SidepanelMonitor();
 
     void clear();
+
+    void set_load_tree_timeout_ms(const int timeout_ms) {
+        _load_tree_timeout_ms = timeout_ms;
+    };
 
 public slots:
 
@@ -46,11 +57,14 @@ private:
     zmq::context_t _zmq_context;
     zmq::socket_t  _zmq_subscriber;
 
+    QTimer* _timer;
+
     bool _connected;
     std::string _connection_address_pub;
     std::string _connection_address_req;
-    QTimer* _timer;
     int _msg_count;
+
+    int _load_tree_timeout_ms;  // Timeout to get behavior tree.
     AbsBehaviorTree _loaded_tree;
     std::unordered_map<int, int> _uid_to_index;
 

--- a/bt_editor/sidepanel_monitor.h
+++ b/bt_editor/sidepanel_monitor.h
@@ -15,7 +15,9 @@ class SidepanelMonitor : public QFrame
     Q_OBJECT
 
 public:
-    explicit SidepanelMonitor(QWidget *parent = nullptr);
+    explicit SidepanelMonitor(QWidget *parent = nullptr,
+                              const QString &publisher_port = "",
+                              const QString &server_port = "");
     ~SidepanelMonitor();
 
     void clear();

--- a/bt_editor/sidepanel_monitor.h
+++ b/bt_editor/sidepanel_monitor.h
@@ -23,13 +23,15 @@ public:
     static constexpr int _load_tree_autoconnect_timeout_ms = 10000;
 
     explicit SidepanelMonitor(QWidget *parent = nullptr,
+                              const QString &address = "",
                               const QString &publisher_port = "",
                               const QString &server_port = "");
     ~SidepanelMonitor();
 
     void clear();
 
-    void set_load_tree_timeout_ms(const int timeout_ms) {
+    void set_load_tree_timeout_ms(const int timeout_ms)
+    {
         _load_tree_timeout_ms = timeout_ms;
     };
 

--- a/bt_editor/sidepanel_monitor.ui
+++ b/bt_editor/sidepanel_monitor.ui
@@ -39,7 +39,7 @@
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="QLineEdit" name="lineEdit">
+      <widget class="QLineEdit" name="lineEdit_address">
        <property name="maximumSize">
         <size>
          <width>16777215</width>


### PR DESCRIPTION
This PR adds some extra options to Groot to configure the BT monitor to start with specific address and publisher/server ports, as well as automatically connect by "clicking" the Connect button in the code, if enabled.

Specifically, it lets us run Groot as follows:

```
ros2 run groot Groot --mode monitor --address 192.168.1.42 --publisher_port 1668 --server_port 1669 --autoconnect
```

The `autoconnect` option effectively does the following:
- Increases the timeout for the ZMQ subscriber to 10 seconds
- Triggers a click of the "Connect" button in code
- The above resets the timeout to the default 1 second for users to manually connect/disconnect with the normal timeout

This addresses https://github.com/BehaviorTree/Groot/issues/133 and https://github.com/BehaviorTree/Groot/issues/166. 