### PR TITLE
Recenter view and set focus when initialized

### DIFF
--- a/bt_editor/mainwindow.cpp
+++ b/bt_editor/mainwindow.cpp
@@ -723,6 +723,14 @@ bool MainWindow::eventFilter(QObject *obj, QEvent *event)
     }
 }
 
+void MainWindow::showEvent(QShowEvent *event)
+{
+    if (!event->spontaneous()) {
+        currentTabInfo()->zoomHomeView();
+        ui->centralwidget->setFocus();
+    }
+}
+
 void MainWindow::resizeEvent(QResizeEvent *)
 {
     on_splitter_splitterMoved();

--- a/bt_editor/mainwindow.h
+++ b/bt_editor/mainwindow.h
@@ -6,6 +6,7 @@
 #include <nodes/Node>
 #include <QTreeWidgetItem>
 #include <QShortcut>
+#include <QShowEvent>
 #include <QTimer>
 #include <deque>
 #include <thread>
@@ -141,6 +142,8 @@ private:
     void updateCurrentMode();
 
     bool eventFilter(QObject *obj, QEvent *event) override;
+
+    void showEvent(QShowEvent *event) override;
 
     void resizeEvent(QResizeEvent *) override;
 


### PR DESCRIPTION
Adding a showEvent to centralize view after opening Groot.

Before:
![groot_before](https://user-images.githubusercontent.com/20625381/194748010-3280a337-0ce4-4593-aee7-6357f9131d9c.png)

After:
![groot_after](https://user-images.githubusercontent.com/20625381/194748024-ab300f58-278e-48f6-bead-b4bc33ec1c0b.png)
