### PR TITLE
Feature: Add save-as button and shortcut

### DIFF
--- a/bt_editor/mainwindow.h
+++ b/bt_editor/mainwindow.h
@@ -98,6 +98,8 @@ public slots:
 
     void on_actionSave_triggered();
 
+    void on_actionSaveAs_triggered();
+
     void onSubtreeSelected(const QString& subtreeName);
 
     void on_splitter_splitterMoved(int pos = 0, int index = 0);
@@ -206,6 +208,8 @@ private:
 
     QString _main_tree;
 
+    QString _loaded_tree_file_path;
+
     SidepanelEditor* _editor_widget;
     SidepanelReplay* _replay_widget;
 #ifdef ZMQ_FOUND
@@ -219,6 +223,7 @@ private:
 
     MainWindow::SavedState saveCurrentState();
     void clearUndoStacks();
+    void saveTree(QString loadedPath = "");
 };
 
 

--- a/bt_editor/mainwindow.ui
+++ b/bt_editor/mainwindow.ui
@@ -367,6 +367,74 @@ QToolButton:disabled{
         </widget>
        </item>
        <item>
+        <widget class="QToolButton" name="toolButtonSaveAsFile">
+         <property name="minimumSize">
+          <size>
+           <width>80</width>
+           <height>70</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>80</width>
+           <height>70</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>9</pointsize>
+          </font>
+         </property>
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
+         </property>
+         <property name="autoFillBackground">
+          <bool>false</bool>
+         </property>
+         <property name="styleSheet">
+          <string notr="true">QToolButton {
+    color:white;
+}
+
+QToolButton:hover{
+   background-color: rgb(110, 110, 110);
+}
+
+QToolButton:pressed{
+  background-color: rgb(50, 150, 0)
+}
+
+QToolButton:disabled{
+  color:gray;
+  background-color: rgb(50, 50, 50)
+}
+</string>
+         </property>
+         <property name="text">
+          <string>Save Tree As</string>
+         </property>
+         <property name="icon">
+          <iconset resource="resources/icons.qrc">
+           <normaloff>:/icons/svg/save_white.svg</normaloff>:/icons/svg/save_white.svg</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>34</width>
+           <height>34</height>
+          </size>
+         </property>
+         <property name="checkable">
+          <bool>false</bool>
+         </property>
+         <property name="toolButtonStyle">
+          <enum>Qt::ToolButtonTextUnderIcon</enum>
+         </property>
+         <property name="autoRaise">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -856,6 +924,14 @@ QToolButton:disabled{
    </property>
    <property name="shortcut">
     <string>Ctrl+S</string>
+   </property>
+  </action>
+  <action name="actionSaveAs">
+   <property name="text">
+    <string>Save</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+S</string>
    </property>
   </action>
   <action name="actionQuit">


### PR DESCRIPTION
*This is only a working proposal. There might be still some things to discuss and adopt*

### Motivation
I often have small tree changes that I want to quickly test. But every save I get the `File-Picker-Dialog` and then I have to double-check that I don't accidentally overwrite the wrong tree file, which takes time ... 

### Changes
- set the default behavior of `Save-Tree-Button` + `Ctrl + S` to save the tree into the latest loaded/saved file
- add `Save-Tree-As-Button` + `Ctrl + Shift + S` to always show  `File-Picker-Dialog` to select save location

### Things to discuss/improve
Here are some items which are not in this PR (yet) and still could be added (after approval of adding this feature)

- Save the latest location in settings
- Add a modified version of `save_white.svg`/... for new behavior