### PR TITLE
Link with ncurses instead of curses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,7 @@ add_library(behavior_tree_editor SHARED
     ${FORMS_HEADERS}
 )
 
-SET(GROOT_DEPENDENCIES QtNodeEditor curses ncursesw tinfo )
+SET(GROOT_DEPENDENCIES QtNodeEditor ncurses ncursesw tinfo )
 
 if(ament_cmake_FOUND)
     ament_target_dependencies(behavior_tree_editor ${dependencies})


### PR DESCRIPTION
Modern Linux distributions ship ncurses, but not curses. Not all alias the latter to the former.