### PR TITLE
Remove duplicated "the" preposition in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ reliable, fast and scalable, get in touch with the main author: dfaconti@aurynro
 
 **Groot** is a Graphical Editor, written in C++ and Qt, to create [BehaviorTrees](https://en.wikipedia.org/wiki/Behavior_tree).
 
-It is compliant with the the library [BehaviorTree.CPP](https://github.com/BehaviorTree/BehaviorTree.CPP).
+It is compliant with the library [BehaviorTree.CPP](https://github.com/BehaviorTree/BehaviorTree.CPP).
 
 [![Groot Editor](groot-screenshot.png)](https://vimeo.com/275066768)
 


### PR DESCRIPTION
Delete misprint in the Readme file.
Duplicated "the".